### PR TITLE
Add events to polar plots

### DIFF
--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -553,7 +553,48 @@ function plotPolar(gd, data, layout) {
     gd._context.setBackground(gd, gd._fullLayout.paper_bgcolor);
     Plots.addLinks(gd);
 
-    return Promise.resolve();
+    gd._fullLayout._paper.selectAll('.chart-group .geometry')
+        .each(function(d, i) {
+            var traceIdx = i;
+            d3.select(this).selectAll('path')
+                .each(function(d, i) {
+                    var valueIndex = i;
+
+                    d3.select(this).on('mouseout', function(pt) {
+                        var args = {
+                            event: d3.event,
+                            points: [pt],
+                            traceIdx: traceIdx,
+                            valueIdx: valueIndex,
+                        };
+
+                        gd.emit('plotly_unhover', args);
+                    });
+
+                    d3.select(this).on('mouseover', function(pt) {
+                        var args = {
+                            event: d3.event,
+                            points: [pt],
+                            traceIdx: traceIdx,
+                            valueIdx: valueIndex,
+                        };
+
+                        gd.emit('plotly_hover', args);
+                    });
+
+                    d3.select(this).on('click', function(pt) {
+                        var args = {
+                            event: d3.event,
+                            points: [pt],
+                            traceIdx: traceIdx,
+                            valueIdx: valueIndex,
+                        };
+                        gd.emit('plotly_click', args);
+                    });
+                });
+        });
+
+    return Promise.resolve(gd);
 }
 
 // convenience function to force a full redraw, mostly for use by plotly.js

--- a/src/plot_api/plot_api.js
+++ b/src/plot_api/plot_api.js
@@ -553,47 +553,6 @@ function plotPolar(gd, data, layout) {
     gd._context.setBackground(gd, gd._fullLayout.paper_bgcolor);
     Plots.addLinks(gd);
 
-    gd._fullLayout._paper.selectAll('.chart-group .geometry')
-        .each(function(d, i) {
-            var traceIdx = i;
-            d3.select(this).selectAll('path')
-                .each(function(d, i) {
-                    var valueIndex = i;
-
-                    d3.select(this).on('mouseout', function(pt) {
-                        var args = {
-                            event: d3.event,
-                            points: [pt],
-                            traceIdx: traceIdx,
-                            valueIdx: valueIndex,
-                        };
-
-                        gd.emit('plotly_unhover', args);
-                    });
-
-                    d3.select(this).on('mouseover', function(pt) {
-                        var args = {
-                            event: d3.event,
-                            points: [pt],
-                            traceIdx: traceIdx,
-                            valueIdx: valueIndex,
-                        };
-
-                        gd.emit('plotly_hover', args);
-                    });
-
-                    d3.select(this).on('click', function(pt) {
-                        var args = {
-                            event: d3.event,
-                            points: [pt],
-                            traceIdx: traceIdx,
-                            valueIdx: valueIndex,
-                        };
-                        gd.emit('plotly_click', args);
-                    });
-                });
-        });
-
     return Promise.resolve(gd);
 }
 

--- a/src/plots/polar/micropolar_manager.js
+++ b/src/plots/polar/micropolar_manager.js
@@ -17,6 +17,7 @@ var Color = require('../../components/color');
 var micropolar = require('./micropolar');
 var UndoManager = require('./undo_manager');
 var extendDeepAll = Lib.extendDeepAll;
+var initInteractions = require('./polar_interact');
 
 var manager = module.exports = {};
 
@@ -38,6 +39,7 @@ manager.framework = function(_gd) {
         _gd.data = config.data;
         _gd.layout = config.layout;
         manager.fillLayout(_gd);
+        initInteractions(_gd);
         return config;
     }
     exports.isPolar = true;

--- a/src/plots/polar/polar_interact.js
+++ b/src/plots/polar/polar_interact.js
@@ -1,0 +1,57 @@
+/**
+* Copyright 2012-2017, Plotly, Inc.
+* All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+
+'use strict';
+
+var d3 = require('d3');
+
+module.exports = function initInteractions(gd) {
+    var fullLayout = gd._fullLayout;
+
+    fullLayout._paper.selectAll('.chart-group .geometry')
+        .each(function(d, i) {
+            var curveNumber = i;
+            d3.select(this).selectAll('path')
+                .each(function(d, i) {
+                    var valueIndex = i;
+
+                    d3.select(this).on('mouseout', function(pt) {
+                        var args = {
+                            event: d3.event,
+                            points: [pt],
+                            curveNumber: curveNumber,
+                            pointNumber: valueIndex,
+                        };
+
+                        gd.emit('plotly_unhover', args);
+                    });
+
+                    d3.select(this).on('mouseover', function(pt) {
+                        var args = {
+                            event: d3.event,
+                            points: [pt],
+                            curveNumber: curveNumber,
+                            pointNumber: valueIndex,
+                        };
+
+                        gd.emit('plotly_hover', args);
+                    });
+
+                    d3.select(this).on('click', function(pt) {
+                        var args = {
+                            event: d3.event,
+                            points: [pt],
+                            curveNumber: curveNumber,
+                            pointNumber: valueIndex,
+                        };
+                        gd.emit('plotly_click', args);
+                    });
+                });
+        });
+};

--- a/tasks/util/strict_d3.js
+++ b/tasks/util/strict_d3.js
@@ -19,7 +19,7 @@ module.exports = transformTools.makeRequireTransform('requireTransform',
 
         if(pathIn === 'd3' && opts.file !== pathToStrictD3Module) {
             pathOut = 'require(\'' + pathToStrictD3Module + '\')';
-			pathOut = pathOut.replace(/\\/g, '/')
+            pathOut = pathOut.replace(/\\/g, '/');
         }
 
         if(pathOut) return cb(null, pathOut);

--- a/tasks/util/strict_d3.js
+++ b/tasks/util/strict_d3.js
@@ -19,6 +19,7 @@ module.exports = transformTools.makeRequireTransform('requireTransform',
 
         if(pathIn === 'd3' && opts.file !== pathToStrictD3Module) {
             pathOut = 'require(\'' + pathToStrictD3Module + '\')';
+			pathOut = pathOut.replace(/\\/g, '/')
         }
 
         if(pathOut) return cb(null, pathOut);


### PR DESCRIPTION
This PR adds following events to Polar Plots in plot_api. See https://github.com/plotly/plotly.js/issues/1463
* plotly_hover
* plotly_unhover
* plotly_click 

The arguments contain followin data.
`{
  event: d3.event
  points: [],
  traceIdx: number,
  valueIdx: number
}`